### PR TITLE
Update files to build new chronos off of mesos 1.2.3

### DIFF
--- a/chronos/chronos-local-behance-template
+++ b/chronos/chronos-local-behance-template
@@ -18,7 +18,7 @@ RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources
     apt-get install -y maven \
     npm \
     default-jdk \
-    mesos=1.0.1-2.0.93.ubuntu1404 \
+    mesos=1.2.3-2.0.1 \
     scala \
     curl && \
     apt-get clean all && \

--- a/chronos/mk.sh
+++ b/chronos/mk.sh
@@ -5,20 +5,30 @@
 set -e
 
 if [ "${#}" -ne 2 ]; then
-    echo "usage: ${0} {chronos-version} {mesos-version}"
+    echo "usage: ${0} {chronos-version} {mesos-version} {repo} [{image_tag}]"
     echo ""
     echo "  If a deb package exists in CWD with {chronos-version} in the name,"
     echo "  it will be used, otherwise chronos will be pulled from the package"
     echo "  repositories."
+    echo "  For {repo} specify org/repository like 'ethos/chronos' for Adobe Platform."
+    echo "  If you want to specify non-DockerHub.com registry, use environment variable 'DOCKER_REGISTRY',"
+    echo "    Ex: 'export DOCKER_REGISTRY=docker-ethos-core-univ-release.dr-uw2.adobeitc.com' for Adobe Platform registry."
+    echo "  Specify '{image_tag}' to override default tag, which is 'chronos-{chronos_version}-mesos-{mesos-version}'."
     exit 1
 fi
 
 CHRONOS_VERSION=${1}
 MESOS_VERSION=${2}
-
+REPO=${3}
 FULL_VERSION="chronos-$CHRONOS_VERSION-mesos-$MESOS_VERSION"
-echo "$FULL_VERSION" > docker-tag
-
+if [[ "${4}" != "" ]] ; then
+  IMAGE_TAG=${4}
+else
+  IMAGE_TAG="$FULL_VERSION"
+fi
+if [[ "$DOCKER_REGISTRY" != "" ]] ; then
+  DOCKER_REGISTRY="${DOCKER_REGISTRY}/"
+echo "$IMAGE_TAG" > docker-tag
 CHRONOS_PKG=$(shopt -s nullglob; echo chronos_*${CHRONOS_VERSION}*.deb)
 if test -n "$CHRONOS_PKG"
 then
@@ -33,6 +43,6 @@ fi
 
 sed -i -e "s/MESOS_VERSION/${MESOS_VERSION}/g" Dockerfile
 
-docker build -t "behance/chronos:${FULL_VERSION}" .
-echo "to push: \"docker push behance/chronos:${FULL_VERSION}\""
+docker build -t "${DOCKER_REGISTRY}${REPO}:${IMAGE_TAG}" .
+echo "to push: \"docker push ${DOCKER_REGISTRY}${REPO}:${IMAGE_TAG}\""
 rm -f Dockerfile


### PR DESCRIPTION
Update chronos scripts to use mesos 1.2.3 and be able to push to any registry and repo you specify